### PR TITLE
New Datadog AWS Integration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# tf-aws-datadog-integration
+# TF - AWS Datadog Integration
 Terraform module for defining an AWS role and policy for integrating with Datadog
+
+## Using the module
+
+```[hcl]
+module "aws_datadog_integration" {
+    source = "github.com/lulibrary/tf-aws-datadog-integration"
+
+    aws_provider_profile = "myproviderprofile"
+    aws_provider_region = "eu-west-1"
+    aws_provider_assume_role_arn = "arn:aws:iam::111111111111:role/OrganizationAccountAccessRole"
+
+    aws_audit_bucket_arn = "arn:aws:s3:::my_audit_bucket"
+    datadog_allow_access_to_audit_bucket = false
+    datadog_aws_account_id = "111111111111"
+    datadog_sts_external_id = "datadog+external+secret"
+}
+```
+
+## Input Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| aws_provider_profile | default | Profile to use from the aws credentials file |
+| aws_provider_region | N/A | Region to initialise the provider in |
+| aws_provider_assume_role_arn | `Empty String` | ARN of the role to assume for the specified provider |
+| aws_audit_bucket_arn | `Empty String` | ARN of the bucket in which cloudtrail logs are stored |
+| datadog_allow_access_to_audit_bucket | false | Should the datadog role be able to get objects in the S3 audit bucket, boolean true/false |
+| datadog_aws_account_id | N/A | ID of the datadog account to allow assuming the role |
+| datadog_sts_external_id | N/A | External ID from datadog for the STS external ID |
+
+## Output Variables
+
+| Variable | Description |
+| --- | --- |
+| role_arn | ARN of the AWS role created for the datadog integration |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,143 @@
+provider "aws" {
+    alias = "module"
+    profile = "${var.aws_provider_profile}"
+    region = "${var.aws_provider_region}"
+    assume_role {
+        role_arn = "${var.aws_provider_assume_role_arn}"
+    }
+}
+
+data "aws_iam_policy_document" "dd_cloudtrail_log_bucket_policy" {
+    provider = "aws.module"
+    statement {
+        sid = "DatadogAWSIntegrationPolicyCloudtrailLogBucket"
+        actions = [
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+            "s3:GetObject"
+        ]
+        resources = [
+            "${var.aws_audit_bucket_arn}",
+            "${var.aws_audit_bucket_arn}/*"
+        ]
+        effect = "Allow"
+    }
+}
+
+data "aws_iam_policy_document" "dd_generic_integration_policy" {
+    provider = "aws.module"
+    statement {
+        sid = "DatadogAWSIntegrationPolicyGeneric"
+        actions = [
+            "autoscaling:Describe*",
+            "budgets:ViewBudget",
+            "cloudtrail:DescribeTrails",
+            "cloudtrail:GetTrailStatus",
+            "cloudwatch:Describe*",
+            "cloudwatch:Get*",
+            "cloudwatch:List*",
+            "codedeploy:List*",
+            "codedeploy:BatchGet*",
+            "directconnect:Describe*",
+            "dynamodb:List*",
+            "dynamodb:Describe*",
+            "ec2:Describe*",
+            "ec2:Get*",
+            "ecs:Describe*",
+            "ecs:List*",
+            "elasticache:Describe*",
+            "elasticache:List*",
+            "elasticfilesystem:DescribeFileSystems",
+            "elasticfilesystem:DescribeTags",
+            "elasticloadbalancing:Describe*",
+            "elasticmapreduce:List*",
+            "elasticmapreduce:Describe*",
+            "es:ListTags",
+            "es:ListDomainNames",
+            "es:DescribeElasticsearchDomains",
+            "kinesis:List*",
+            "kinesis:Describe*",
+            "lambda:List*",
+            "logs:Get*",
+            "logs:Describe*",
+            "logs:FilterLogEvents",
+            "logs:TestMetricFilter",
+            "rds:Describe*",
+            "rds:List*",
+            "route53:List*",
+            "s3:GetBucketTagging",
+            "s3:ListAllMyBuckets",
+            "ses:Get*",
+            "sns:List*",
+            "sns:Publish",
+            "sqs:ListQueues",
+            "support:*",
+            "tag:getResources",
+            "tag:getTagKeys",
+            "tag:getTagValues"
+        ]
+        resources = [
+            "*"
+        ]
+        effect = "Allow"
+    }
+}
+
+data "aws_iam_policy_document" "dd_assume_role_policy" {
+    provider = "aws.module"
+    statement {
+        sid = "DatadogAWSIntegrationAssumeRolePolicy"
+        actions = [
+            "sts:AssumeRole"
+        ]
+        principals {
+            type = "AWS"
+            identifiers = [
+                "arn:aws:iam::${var.datadog_aws_account_id}:root"
+            ]
+        }
+        effect = "Allow"
+        condition {
+            test = "StringEquals"
+            variable = "sts:ExternalId"
+            values = [
+                "${var.datadog_sts_external_id}"
+            ]
+        }
+    }
+}
+
+resource "aws_iam_policy" "dd_account_integration_policy" {
+    provider = "aws.module"
+    name        = "DatadogAWSIntegrationPolicyGeneric"
+    path        = "/"
+    description = "DatadogAWSIntegrationPolicyGeneric"
+    policy = "${data.aws_iam_policy_document.dd_generic_integration_policy.json}"
+}
+
+resource "aws_iam_policy" "dd_account_storage_integration_policy" {
+    provider = "aws.module"
+    name = "DatadogAWSIntegrationPolicyCloudtrailLogBucket"
+    path = "/"
+    description = "DatadogAWSIntegrationPolicyCloudtrailLogBucket"
+    policy = "${data.aws_iam_policy_document.dd_cloudtrail_log_bucket_policy.json}"
+}
+
+resource "aws_iam_role" "dd_account_integration_role" {
+    provider = "aws.module"
+    name = "DatadogAWSIntegrationRole"
+    assume_role_policy = "${data.aws_iam_policy_document.dd_assume_role_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dd_account_role" {
+    provider = "aws.module"
+    role = "${aws_iam_role.dd_account_integration_role.name}"
+    policy_arn = "${aws_iam_policy.dd_account_integration_policy.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "allow_dd_account_role_audit" {
+    count = "${var.datadog_allow_access_to_audit_bucket}"
+    provider = "aws.module"
+    role = "${aws_iam_role.dd_account_integration_role.name}"
+    policy_arn = "${aws_iam_policy.dd_account_storage_integration_policy.arn}"
+}

--- a/output.tf
+++ b/output.tf
@@ -1,0 +1,4 @@
+output "role_arn" {
+    value = "${aws_iam_role.dd_account_integration_role.arn}"
+    description = "ARN of the AWS role created for the datadog integration"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_provider_profile" {
+    description = "AWS profile to use for the AWS provider"
+    default = "default"
+}
+
+variable "aws_provider_region" {
+    description = "AWS region to use for the AWS provider"
+}
+
+variable "aws_provider_assume_role_arn" {
+    description = "ARN of role to assume for the AWS provider"
+    default = ""
+}
+
+variable "aws_audit_bucket_arn" {
+    description ="ARN of the bucket in which cloudtrail logs are stored"
+    default = "" 
+}
+
+variable "datadog_allow_access_to_audit_bucket" {
+    description = "Should the datadog role be able to get objects in the S3 audit bucket"
+    default = false
+}
+
+variable "datadog_aws_account_id" {
+    description = "ID of the datadog account to allow assuming the role"
+}
+
+variable "datadog_sts_external_id" {
+    description = "External ID from datadog for the STS external ID"
+}


### PR DESCRIPTION
Defines the IAM policies and roles for allowing Datadog to integrate with the specified AWS account. Allows configuring access to a cloudtrail audit bucket to allow the Datadog cloudtrail module to work.